### PR TITLE
Add pipeline filter so that it could filter by pipeline names

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,3 +5,4 @@ applications:
     buildpack: https://github.com/crystal-lang/heroku-buildpack-crystal.git
     env:
       HOSTS: ci.concourse.ci appdog.ci.cf-app.com buildpacks.ci.cf-app.com diego.ci.cf-app.com capi.ci.cf-app.com
+#     PIPELINES: pipeline_name_1 pipeline_name_2 (it will only display the pipeline name apears here or all if you leave it unset)

--- a/spec/pipeline_spec.cr
+++ b/spec/pipeline_spec.cr
@@ -18,8 +18,16 @@ describe "Pipeline" do
       response = Mocks.double("Response", returns(status_code, 200), returns(body, %([{"name":"fred","url":"","paused":false},{"name":"jane","url":"","paused":false}])))
       client = Mocks.double("Client", returns(get("/api/v1/pipelines"), response))
 
-      pipelines = Pipeline.all(client)
+      pipelines = Pipeline.all(client, [] of String)
       pipelines.map(&.name).should eq ["fred","jane"]
+    end
+
+    it "returns filtered pipelines" do
+      response = Mocks.double("Response", returns(status_code, 200), returns(body, %([{"name":"fred","url":"","paused":false},{"name":"jane","url":"","paused":false}])))
+      client = Mocks.double("Client", returns(get("/api/v1/pipelines"), response))
+
+      pipelines = Pipeline.all(client, ["fred"])
+      pipelines.map(&.name).should eq ["fred"]
     end
 
     it "raises exception if 401 status code is returned" do
@@ -27,7 +35,7 @@ describe "Pipeline" do
       client = Mocks.double("Client", returns(get("/api/v1/pipelines"), response))
 
       expect_raises Unauthorized do
-        Pipeline.all(client)
+        Pipeline.all(client, [] of String)
       end
     end
   end

--- a/src/concourse-summary.cr
+++ b/src/concourse-summary.cr
@@ -12,7 +12,8 @@ get "/host/:host" do |env|
   username = env.store["credentials_username"]?
   password = env.store["credentials_password"]?
   ignore_groups = env.params.query.has_key?("ignore_groups")
-  data = MyData.get_data(host, username, password)
+  filters = (ENV["PIPELINES"]? || "").split(/\s+/)
+  data = MyData.get_data(host, username, password, filters)
   if (ignore_groups)
     data = MyData.remove_group_info(data)
   end

--- a/src/concourse-summary/my_data.cr
+++ b/src/concourse-summary/my_data.cr
@@ -32,11 +32,11 @@ class MyData
     (@statuses[status].to_f / @statuses.values.sum * 100).floor.to_i
   end
 
-  def self.get_data(host, username, password)
+  def self.get_data(host, username, password, filters)
     client = HTTP::Client.new(host, tls: true)
     client.basic_auth(username, password)
 
-    Pipeline.all(client).map do |pipeline|
+    Pipeline.all(client, filters).map do |pipeline|
       Job.all(client, pipeline.url).map do |job|
         {pipeline, job}
       end

--- a/src/concourse-summary/pipeline.cr
+++ b/src/concourse-summary/pipeline.cr
@@ -8,9 +8,13 @@ class Pipeline
     paused: Bool
   )
 
-  def self.all(client)
+  def self.all(client, filters)
     response = client.get("/api/v1/pipelines")
     raise Unauthorized.new if response.status_code == 401
-    Array(Pipeline).from_json(response.body)
+    all_the_pipes = Array(Pipeline).from_json(response.body)
+    unless filters.empty?
+      all_the_pipes.select! { |p| filters.includes?(p.name) }
+    end
+    all_the_pipes
   end
 end


### PR DESCRIPTION
Hi Dave:

Thanks for the concourse-summary project, which is super helpful for us (we are in Pivotal SF) !

This works great for us, yet we want to be able to apply filters for the pipelines because we have different teams in different geographic locations who shared the same concourse server but have different pipelines.

So that we'd like to be able to push multiple instances of this app but apply different pipeline filters.

Below are the PR we've created, It does not change the default behavior unless you config PIPELINES in your env, which will show only the pipelines configured in PIPELINES env.

We think this might also benefit other teams, any comments?
