### PR TITLE
Login via the api instead of a form post

### DIFF
--- a/src/concourse-summary/my_data.cr
+++ b/src/concourse-summary/my_data.cr
@@ -101,7 +101,8 @@ class MyData
     client = HTTP::Client.new(host, tls: true)
     if username.to_s.size > 0
       if login_form
-        resp = client.post_form("/teams/main/login", { "username" => username.to_s, "password" => password.to_s })
+        client.basic_auth(username.to_s, password.to_s)
+        resp = client.get("/api/v1/teams/main/auth/token")
         cookie = resp.headers["Set-Cookie"].split(";").first
         client.before_request { |request| request.headers["Cookie"] = cookie }
       else


### PR DESCRIPTION
As of concourse 2.4.0, the implementation that was posting to the login form was no longer correctly authenticating.  This PR switches to using the api method to get an auth token.