### PR TITLE
Fix 3.8.1 Concourse Pipeline processing

### DIFF
--- a/src/concourse-summary/pipeline.cr
+++ b/src/concourse-summary/pipeline.cr
@@ -4,14 +4,20 @@ require "./exceptions"
 class Pipeline
   JSON.mapping(
     name: String,
-    url: String,
+    team_name: String,
     paused: Bool
   )
+
+  property url : String = ""
 
   def self.all(client)
     response = client.get("/api/v1/pipelines")
     raise Unauthorized.new if response.status_code == 401
     return [] of Pipeline if response.status_code == 500
-    Array(Pipeline).from_json(response.body)
+    pipelines = Array(Pipeline).from_json(response.body)
+    pipelines.each do |pipeline|
+      pipeline.url = "/teams/#{pipeline.team_name}/pipelines/#{pipeline.name}"
+    end
+    return pipelines
   end
 end


### PR DESCRIPTION
Concourse 3.8.1 removed the `url` property from the
response of the /teams/$TEAM/pipelines/$PIPELINE endpoint.
We can synthesize this data from the rest of the response.
So, we do that.

Signed-off-by: Derwei Chan <dchan@pivotal.io>