### PR TITLE
URL encode pipeline names

### DIFF
--- a/spec/pipeline_spec.cr
+++ b/spec/pipeline_spec.cr
@@ -24,11 +24,12 @@ end
 describe "Pipeline" do
   describe ".all" do
     it "returns requested pipelines" do
-      response = Response.new(200, %([{"name":"fred","team_name":"","paused":false},{"name":"jane","team_name":"","paused":false}]))
+      response = Response.new(200, %([{"name":"fred pipeline","team_name":"main","paused":false},{"name":"jane","team_name":"team1","paused":false}]))
       client = Client.new("/api/v1/pipelines", response)
 
       pipelines = Pipeline.all(client)
-      pipelines.map(&.name).should eq ["fred","jane"]
+      pipelines.map(&.name).should eq ["fred pipeline","jane"]
+      pipelines.map(&.url).should eq ["/teams/main/pipelines/fred%20pipeline", "/teams/team1/pipelines/jane"]
     end
 
     it "raises exception if 401 status code is returned" do

--- a/src/concourse-summary/pipeline.cr
+++ b/src/concourse-summary/pipeline.cr
@@ -16,7 +16,7 @@ class Pipeline
     return [] of Pipeline if response.status_code == 500
     pipelines = Array(Pipeline).from_json(response.body)
     pipelines.each do |pipeline|
-      pipeline.url = "/teams/#{pipeline.team_name}/pipelines/#{pipeline.name}"
+      pipeline.url = "/teams/#{pipeline.team_name}/pipelines/#{URI.escape(pipeline.name)}"
     end
     return pipelines
   end


### PR DESCRIPTION
We generate the URL to the pipeline with the pipeline name. This caused an issue where previously we were not URL encoding the pipeline name. So special characters would result in an invalid pipeline URL.